### PR TITLE
[feat] 레이저 투사체 프리팹 및 스크립트 추가, 발사 기능 추가, 레이저 포인터 경로 제한

### DIFF
--- a/Assets/Prefabs/LaserProjectile.prefab
+++ b/Assets/Prefabs/LaserProjectile.prefab
@@ -1,0 +1,258 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &4192507857642365857
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5694450870886946812}
+  - component: {fileID: 5367986366055221869}
+  - component: {fileID: 4766061968437433620}
+  - component: {fileID: 8299219670364107707}
+  - component: {fileID: 5555628380335635665}
+  - component: {fileID: 2612242778195264175}
+  - component: {fileID: 3188414701400120147}
+  m_Layer: 0
+  m_Name: LaserProjectile
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5694450870886946812
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4192507857642365857}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.7071068, y: 0, z: 0, w: 0.7071068}
+  m_LocalPosition: {x: 1.783, y: 0.000000004983, z: 3e-15}
+  m_LocalScale: {x: 0.1, y: 0.26480085, z: 0.1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 90, y: 0, z: 0}
+--- !u!33 &5367986366055221869
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4192507857642365857}
+  m_Mesh: {fileID: 10208, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &4766061968437433620
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4192507857642365857}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 104dfe4e9eaf15e42b9645fc2a6f54eb, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!136 &8299219670364107707
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4192507857642365857}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 1
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Radius: 0.5000001
+  m_Height: 0.3776424
+  m_Direction: 1
+  m_Center: {x: 0.000000074505806, y: 0.58, z: -0.00000007450582}
+--- !u!54 &5555628380335635665
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4192507857642365857}
+  serializedVersion: 4
+  m_Mass: 1
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_CenterOfMass: {x: 0, y: 0, z: 0}
+  m_InertiaTensor: {x: 1, y: 1, z: 1}
+  m_InertiaRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ImplicitCom: 1
+  m_ImplicitTensor: 1
+  m_UseGravity: 1
+  m_IsKinematic: 1
+  m_Interpolate: 0
+  m_Constraints: 0
+  m_CollisionDetection: 0
+--- !u!114 &2612242778195264175
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4192507857642365857}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 49a73243e1d96584bb27b66ca1077784, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  speed: 14
+  lifeTime: 3
+  damage: 10
+--- !u!96 &3188414701400120147
+TrailRenderer:
+  serializedVersion: 3
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4192507857642365857}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 0
+  m_LightProbeUsage: 0
+  m_ReflectionProbeUsage: 0
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10301, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Time: 0.1
+  m_PreviewTimeScale: 1
+  m_Parameters:
+    serializedVersion: 3
+    widthMultiplier: 1
+    widthCurve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0.018779755
+        value: 0.1744194
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 0
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    colorGradient:
+      serializedVersion: 2
+      key0: {r: 0.98039216, g: 0.29385313, b: 0, a: 1}
+      key1: {r: 1, g: 1, b: 1, a: 1}
+      key2: {r: 0, g: 0, b: 0, a: 0}
+      key3: {r: 0, g: 0, b: 0, a: 0}
+      key4: {r: 0, g: 0, b: 0, a: 0}
+      key5: {r: 0, g: 0, b: 0, a: 0}
+      key6: {r: 0, g: 0, b: 0, a: 0}
+      key7: {r: 0, g: 0, b: 0, a: 0}
+      ctime0: 0
+      ctime1: 65535
+      ctime2: 0
+      ctime3: 0
+      ctime4: 0
+      ctime5: 0
+      ctime6: 0
+      ctime7: 0
+      atime0: 0
+      atime1: 65535
+      atime2: 0
+      atime3: 0
+      atime4: 0
+      atime5: 0
+      atime6: 0
+      atime7: 0
+      m_Mode: 0
+      m_ColorSpace: 0
+      m_NumColorKeys: 2
+      m_NumAlphaKeys: 2
+    numCornerVertices: 0
+    numCapVertices: 0
+    alignment: 0
+    textureMode: 0
+    textureScale: {x: 1, y: 1}
+    shadowBias: 0.5
+    generateLightingData: 0
+  m_MinVertexDistance: 0.1
+  m_MaskInteraction: 0
+  m_Autodestruct: 0
+  m_Emitting: 1
+  m_ApplyActiveColorSpace: 1

--- a/Assets/Prefabs/LaserProjectile.prefab.meta
+++ b/Assets/Prefabs/LaserProjectile.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 8bebcda0ef455c24d9d92b8937b5832a
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/SYScene.unity
+++ b/Assets/Scenes/SYScene.unity
@@ -787,7 +787,6 @@ GameObject:
   - component: {fileID: 1530142521072749604}
   - component: {fileID: 939289572}
   - component: {fileID: 2195496196379989663}
-  - component: {fileID: 2195496196379989664}
   m_Layer: 0
   m_Name: Lazer
   m_TagString: Untagged
@@ -809,25 +808,10 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   startPoint: {fileID: 1716933824}
   target: {fileID: 0}
-  laserLength: 20
+  obstacleMask:
+    serializedVersion: 2
+    m_Bits: 55
   lineRenderer: {fileID: 0}
---- !u!114 &2195496196379989664
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2195496196379989662}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0022d8739ee584a4aae8d1a0f05121c0, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  laserPointer: {fileID: 0}
-  lineRenderer: {fileID: 0}
-  maxDistance: 30
-  hitLayers:
-    m_Bits: 64
 --- !u!23 &3755535863784558950
 MeshRenderer:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/SYScene.unity
+++ b/Assets/Scenes/SYScene.unity
@@ -123,6 +123,111 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
+--- !u!1 &588426836
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 588426840}
+  - component: {fileID: 588426839}
+  - component: {fileID: 588426838}
+  - component: {fileID: 588426837}
+  m_Layer: 0
+  m_Name: Cube
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!65 &588426837
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 588426836}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!23 &588426838
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 588426836}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &588426839
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 588426836}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!4 &588426840
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 588426836}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0.235, y: -0.019136548, z: 4.96}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &651345364
 GameObject:
   m_ObjectHideFlags: 0
@@ -350,7 +455,7 @@ Transform:
   m_GameObject: {fileID: 725501615}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 4.924}
+  m_LocalPosition: {x: 0, y: 0, z: 8.77}
   m_LocalScale: {x: 0.5, y: 0.5, z: 0.5}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -372,7 +477,7 @@ MonoBehaviour:
   turretHead: {fileID: 8478664868257075048}
   rotationSpeed: 270
   detectionSpeed: 5
-  detectionRange: 5
+  detectionRange: 10
   target: {fileID: 0}
   targetLayerMask:
     serializedVersion: 2
@@ -478,8 +583,8 @@ LineRenderer:
       m_RotationOrder: 4
     colorGradient:
       serializedVersion: 2
-      key0: {r: 1, g: 0, b: 0, a: 1}
-      key1: {r: 1, g: 1, b: 1, a: 1}
+      key0: {r: 1, g: 0, b: 0, a: 0.39215687}
+      key1: {r: 1, g: 0, b: 0, a: 0.39215687}
       key2: {r: 0, g: 0, b: 0, a: 0}
       key3: {r: 0, g: 0, b: 0, a: 0}
       key4: {r: 0, g: 0, b: 0, a: 0}
@@ -502,8 +607,8 @@ LineRenderer:
       atime5: 0
       atime6: 0
       atime7: 0
-      m_Mode: 0
-      m_ColorSpace: -1
+      m_Mode: 2
+      m_ColorSpace: 0
       m_NumColorKeys: 2
       m_NumAlphaKeys: 2
     numCornerVertices: 0
@@ -704,6 +809,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   startPoint: {fileID: 1716933824}
   target: {fileID: 0}
+  laserLength: 20
   lineRenderer: {fileID: 0}
 --- !u!114 &2195496196379989664
 MonoBehaviour:
@@ -900,3 +1006,4 @@ SceneRoots:
   - {fileID: 651345366}
   - {fileID: 673685083}
   - {fileID: 725501619}
+  - {fileID: 588426840}

--- a/Assets/Scenes/SYScene.unity
+++ b/Assets/Scenes/SYScene.unity
@@ -811,7 +811,7 @@ MonoBehaviour:
   obstacleMask:
     serializedVersion: 2
     m_Bits: 55
-  lineRenderer: {fileID: 0}
+  lineRenderer: {fileID: 1716933825}
 --- !u!23 &3755535863784558950
 MeshRenderer:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/SYScene.unity
+++ b/Assets/Scenes/SYScene.unity
@@ -377,7 +377,10 @@ MonoBehaviour:
   targetLayerMask:
     serializedVersion: 2
     m_Bits: 64
-  laserPointer: {fileID: 0}
+  laserPrefab: {fileID: 4192507857642365857, guid: 8bebcda0ef455c24d9d92b8937b5832a, type: 3}
+  firePoint: {fileID: 1716933824}
+  fireCooldown: 1
+  laserPointer: {fileID: 2195496196379989663}
 --- !u!1 &1716933823
 GameObject:
   m_ObjectHideFlags: 0
@@ -679,6 +682,7 @@ GameObject:
   - component: {fileID: 1530142521072749604}
   - component: {fileID: 939289572}
   - component: {fileID: 2195496196379989663}
+  - component: {fileID: 2195496196379989664}
   m_Layer: 0
   m_Name: Lazer
   m_TagString: Untagged
@@ -700,8 +704,24 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   startPoint: {fileID: 1716933824}
   target: {fileID: 0}
-  laserLength: 20
   lineRenderer: {fileID: 0}
+--- !u!114 &2195496196379989664
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2195496196379989662}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0022d8739ee584a4aae8d1a0f05121c0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  laserPointer: {fileID: 0}
+  lineRenderer: {fileID: 0}
+  maxDistance: 30
+  hitLayers:
+    m_Bits: 64
 --- !u!23 &3755535863784558950
 MeshRenderer:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Obstacles/IObstacle.cs
+++ b/Assets/Scripts/Obstacles/IObstacle.cs
@@ -4,6 +4,6 @@ using UnityEngine;
 
 public interface IObstacle 
 {
-    void Activate(); // Àå¾Ö¹° È°¼ºÈ­
-    void Deactivate(); // Àå¾Ö¹° ºñÈ°¼ºÈ­
+    void Activate(); // ìž¥ì• ë¬¼ í™œì„±í™”
+    void Deactivate(); // ìž¥ì• ë¬¼ ë¹„í™œì„±í™”
 }

--- a/Assets/Scripts/Obstacles/LaserPointer.cs
+++ b/Assets/Scripts/Obstacles/LaserPointer.cs
@@ -5,15 +5,20 @@ using UnityEngine;
 public class LaserPointer : MonoBehaviour
 {
     [SerializeField] private Transform startPoint; // 포인터 시작점
-    public Transform target;
-    [SerializeField] private float laserLength = 20f; // 레이저 길이
-
+    [SerializeField] Transform target; // 타겟
+    [SerializeField] LayerMask obstacleMask;  // 타겟 이외 오브젝트들(벽, 장애물 등)
     [SerializeField] private LineRenderer lineRenderer;
 
+    private Ray ray;             
+    private RaycastHit rayHit;  
 
     void Start()
     {
-        lineRenderer = GetComponentInChildren<LineRenderer>();
+        if(lineRenderer == null)
+        {  
+            lineRenderer = GetComponent<LineRenderer>(); 
+        }
+
         lineRenderer.positionCount = 2; // 레이저 포인터 점 갯수
     }
 
@@ -21,7 +26,18 @@ public class LaserPointer : MonoBehaviour
     {
         if(target != null)
         {
-            OnLaser(startPoint.position, target.position);
+            Vector3 direction = target.position - startPoint.position;
+            ray = new Ray(startPoint.position, direction);
+
+            // 벽이나 장애물 뒤에 타겟이 숨을 경우 레이저가 벽, 장애물까지만 표시되도록 경로 제한
+            if (Physics.Raycast(ray, out rayHit, direction.magnitude, obstacleMask))
+            {
+                OnLaser(startPoint.position, rayHit.point);
+            }
+            else
+            {
+                OnLaser(startPoint.position, target.position);
+            }          
         }
         else
         {

--- a/Assets/Scripts/Obstacles/LaserProjectile.cs
+++ b/Assets/Scripts/Obstacles/LaserProjectile.cs
@@ -1,0 +1,27 @@
+using UnityEngine;
+public class LaserProjectile : MonoBehaviour
+{
+    [Header("Projectile Settings")]
+    [SerializeField] private float speed = 15f; // 레이저 속도
+    [SerializeField] private float lifeTime = 2f; // 레이저 지속시간
+    [SerializeField] private float damage = 10f; // 레이저 대미지
+
+    private Vector3 direction; // 레이저 방향
+
+    private void Update()
+    {
+        transform.position += direction * speed * Time.deltaTime;
+    }
+    public void Init(Vector3 dir) // 레이저 프리팹 초기화
+    {
+        direction = dir.normalized;
+        Destroy(gameObject, lifeTime);
+    }
+
+    private void OnTriggerEnter(Collider other)
+    {
+        // 데미지 관련 내용 추가
+        Destroy(gameObject);
+    }
+
+}

--- a/Assets/Scripts/Obstacles/LaserProjectile.cs.meta
+++ b/Assets/Scripts/Obstacles/LaserProjectile.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 49a73243e1d96584bb27b66ca1077784
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Obstacles/Turret.cs
+++ b/Assets/Scripts/Obstacles/Turret.cs
@@ -15,6 +15,13 @@ public class Turret : ObstacleBase
     [SerializeField] private Transform target; // 타겟(플레이어)
     [SerializeField] private LayerMask targetLayerMask = 0; // Player 레이어
 
+    [Header("Turret Fire Settings")]
+    [SerializeField] private GameObject laserPrefab; // 레이저 투사체 프리팹
+    [SerializeField] private Transform firePoint; // 레이저 발사 위치
+    [SerializeField] private float fireCooldown = 1f; // 레이저 발사 주기
+
+    private float lastFireTime = 0f;
+
     [SerializeField] private LaserPointer laserPointer; // 레이저 포인터
 
     private void Awake()
@@ -75,6 +82,7 @@ public class Turret : ObstacleBase
             if (angleToTarget < 5f)
             {
                 laserPointer.SetTarget(target);
+                Fire();
             }
             else
             {
@@ -82,4 +90,23 @@ public class Turret : ObstacleBase
             }
         }
     }
+
+    public void Fire()
+    {
+        if (target == null || Time.time < lastFireTime + fireCooldown) return;
+
+        Vector3 direction = (target.position - firePoint.position).normalized; // 발사 방향
+        Quaternion rotation = Quaternion.LookRotation(direction);
+        rotation *= Quaternion.Euler(90f,0,0); // 발사각도
+
+        GameObject laser = Instantiate(laserPrefab, firePoint.position, rotation);
+        LaserProjectile projectile = laser.GetComponent<LaserProjectile>();
+        if (projectile != null)
+        {
+            projectile.Init(direction);
+        }
+
+        lastFireTime = Time.time;
+    }
+
 }


### PR DESCRIPTION
## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 에셋 또는 리소스 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [x] 파일 혹은 폴더 추가
- [ ] 파일 혹은 폴더 삭제

## 📝작업 내용

- LaserProjectile 프리팹, LaserProjectile.cs 스크립트 추가
- Turret.cs 스크립트에서 레이저 발사(Fire) 메서드 추가
- LaserPointer.cs 스크립트에 Raycast로 레이저 경로를 제한하도록 코드 리팩토링

### 스크린샷 
![녹음 2025-08-16 040212](https://github.com/user-attachments/assets/1a608596-387a-4f8c-96aa-608e2738a950)

## 💬리뷰 요구사항
LaserProjectile.cs, Turret.cs, LaserPointer.cs 위주로 리뷰 요망

일단 LaserProjectile 프리팹을 발사 시 생성되고 오브젝트 콜라이더에 닿으면 파괴되는 방식으로 구현을 했습니다.
생성/파괴 방식은 성능에 영향을 미친다고 알고있긴한데 어떻게 바꾸면 좋을지 잘 모르겠습니다. 좋은 수정방안이 있다면 의견 부탁드립니다.

### ETC
- LaserProjectile의 OnTriggerEnter에서 추후 플레이어의 체력이 구현된다면 데미지를 주는 기능을 추가하면 될것같습니다.
- LaserPointer에 Raycast 기능을 추가했는데 덕분에 LayserPointer 자체로도 장애물로 활용할 수 있을것 같습니다.
  - 당장 생각나는건 레이저를 벽이나 문에 설치해서 플레이어의 이동경로를 제한하는 방법이 있을것같은데 그 외에도 혹시 생각나시는게 있다면 의견좀 부탁드립니다.

