### PR TITLE
[Fix] 아이템 획득 시 아이템 커짐 현상 수정 / 플레이어 콜라이더 위치 오류 현상(특정 구역 점프 안됨 현상)

### DIFF
--- a/Assets/Scenes/TestScene.unity
+++ b/Assets/Scenes/TestScene.unity
@@ -10772,6 +10772,10 @@ PrefabInstance:
       propertyPath: m_Radius
       value: 0.25
       objectReference: {fileID: 0}
+    - target: {fileID: 2692970904949343008, guid: 0f3f0d28963039046a0d8aba86d42eee, type: 3}
+      propertyPath: m_Center.y
+      value: 0.72
+      objectReference: {fileID: 0}
     - target: {fileID: 3038640973848435899, guid: 0f3f0d28963039046a0d8aba86d42eee, type: 3}
       propertyPath: m_Drag
       value: 0
@@ -10817,16 +10821,28 @@ PrefabInstance:
       value: 3000
       objectReference: {fileID: 0}
     - target: {fileID: 8250812686003972975, guid: 0f3f0d28963039046a0d8aba86d42eee, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 0.46
+      objectReference: {fileID: 0}
+    - target: {fileID: 8250812686003972975, guid: 0f3f0d28963039046a0d8aba86d42eee, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 0.46
+      objectReference: {fileID: 0}
+    - target: {fileID: 8250812686003972975, guid: 0f3f0d28963039046a0d8aba86d42eee, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 0.46
+      objectReference: {fileID: 0}
+    - target: {fileID: 8250812686003972975, guid: 0f3f0d28963039046a0d8aba86d42eee, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -0.557
+      value: -0.161
       objectReference: {fileID: 0}
     - target: {fileID: 8250812686003972975, guid: 0f3f0d28963039046a0d8aba86d42eee, type: 3}
       propertyPath: m_LocalPosition.y
-      value: -0.23
+      value: -0.064
       objectReference: {fileID: 0}
     - target: {fileID: 8250812686003972975, guid: 0f3f0d28963039046a0d8aba86d42eee, type: 3}
       propertyPath: m_LocalPosition.z
-      value: 0.078
+      value: 0.131
       objectReference: {fileID: 0}
     - target: {fileID: 8841467904427936749, guid: 0f3f0d28963039046a0d8aba86d42eee, type: 3}
       propertyPath: m_LocalPosition.x


### PR DESCRIPTION
##  #️⃣연관된 이슈


> ex) #이슈번호, #이슈번호


## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 에셋 또는 리소스 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 추가
- [ ] 파일 혹은 폴더 삭제

## 📝작업 내용
1. 아이템 획득 시 아이템이 커지는 현상
아이템의 크기가 그대로 적용되도록 수정했습니다.
사이드 이펙트로 들고 있는 아이템은 그대로인데 왼팔의 애니메이션으로 인해 손이 앞으로 튀어나가 부자연스러워 보입니다.
방법1. 애니메이션에 사용된 골격을 찾아 아이템을 자식으로 둡니다. (cube를 자식으로 두면 됩니다.)
방법2. 아이템 획득 시 왼팔을 카메라에서 안보이게 설정합니다.

1번 방법이 가장 좋으나 골격 위치를 못찾을 경우 2번 방법으로 진행예정입니다.



----------------------------------------
2. 플레이어의 콜라이더  위치 오류 현상
캡슐 콜라이더의 위치를 수정하여 특정 지역에서 점프가 안되는 현상을 수정하였습니다.

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)


### 스크린샷 (선택)


## 💬리뷰 요구사항(선택)


> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

>

> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

